### PR TITLE
Locality based suggestions and fixes

### DIFF
--- a/lib/inline-autocomplete.coffee
+++ b/lib/inline-autocomplete.coffee
@@ -35,7 +35,7 @@ module.exports =
     @deactivationDisposables.add atom.workspace.observeTextEditors (editor) =>
       editorView = atom.views.getView editor
       editorView.onkeydown = (e) =>
-        @reset() if (e.keyCode in confirmKeys) and editorView and editorView.classList.contains('inline-autocompleting')
+        @reset() unless (e.keyCode in confirmKeys) and editorView and editorView.classList.contains('inline-autocompleting')
 
       disposable = new Disposable => @reset()
       @deactivationDisposables.add editor.onDidDestroy -> disposable.dispose()
@@ -157,7 +157,7 @@ module.exports =
         true
       )
 
-      {prefix, suffix, word}  for {word} in closestWords when regex.test(word) and word != currentWord.word
+      {prefix, suffix, word} for {word} in closestWords when regex.test(word) and word != currentWord.word
     else
       {word, prefix, suffix} for {word} in @wordList
 

--- a/lib/inline-autocomplete.coffee
+++ b/lib/inline-autocomplete.coffee
@@ -110,7 +110,7 @@ module.exports =
       if grammar and grammar.rawPatterns
         for rawPattern in grammar.rawPatterns
           if rawPattern.match
-            strippedPattern = rawPattern.match.replace(/\\.{1}/g, '')
+            strippedPattern = rawPattern.match.replace(/\\.{2}/g, '')
             matches = strippedPattern.match(@wordRegex)
             continue unless matches?
             for word in matches

--- a/lib/word-node.coffee
+++ b/lib/word-node.coffee
@@ -1,0 +1,15 @@
+class WordNode
+  constructor: ({@word, @buffer, @row}) ->
+
+  distanceFrom: (otherWord) ->
+    linesOffset = if @buffer? then @buffer.getLineCount() else 0
+    bufferDiff = if @buffer? && otherWord.buffer? then @buffer.id.localeCompare(otherWord.buffer.id) else 3
+    Math.abs(bufferDiff * linesOffset + (otherWord.row - @row))
+
+  buffersCount: ->
+    buffers.size
+
+  resetBuffersCount: ->
+    buffers.clear()
+
+module.exports = WordNode

--- a/spec/word-node-spec.coffee
+++ b/spec/word-node-spec.coffee
@@ -1,0 +1,35 @@
+WordNode = require '../lib/word-node'
+{TextBuffer} = require 'atom'
+
+describe "WordNode", ->
+  [word, buffer1] = []
+
+  beforeEach ->
+    buffer1 = new TextBuffer "A\ntest\nother\nstuff"
+    word = new WordNode word: 'te', buffer: buffer1, row: 1
+
+  describe "attributes", ->
+    it "saves word, buffer, and row", ->
+      expect(word.row).toEqual 1
+      expect(word.word).toEqual 'te'
+      expect(word.buffer).toEqual buffer1
+
+  describe "distanceFrom", ->
+    it "returns the difference between rows if on same buffer", ->
+      otherWord = new WordNode({word: 'test', buffer: buffer1, row: 3})
+      expect(word.distanceFrom(otherWord)).toEqual 2
+
+    it "skews row by number buffer line count used buffers if other word node is on different buffer", ->
+      word = new WordNode word: 'te', buffer: buffer1, row: 1
+      buffer2 = new TextBuffer "Other\nbuffer\ntest other"
+      otherBufferWord = new WordNode({word: 'test', buffer: buffer2, row: 2})
+      expect(word.distanceFrom(otherBufferWord)).toEqual 5
+
+    it "does not skew row distance if buffer is null", ->
+      noBufferWord = new WordNode word: "tests", row: 2
+      expect(noBufferWord.distanceFrom(word)).toEqual 1
+
+    it "does not skew row distance if both word node buffers are null", ->
+      noBufferWord = new WordNode word: "t", row: 2
+      noBufferWord2 = new WordNode word: "tests", row: 5
+      expect(noBufferWord.distanceFrom(noBufferWord2)).toEqual 3


### PR DESCRIPTION
Experiment with returning search results based on line distance of closest match. Not sure if it makes it slower.

To use, check `Suggest Closest` in plugin settings.

* fixes cycling autocomplete. backward cycling still broken
* attempt to dispose of events and listeners when package is deactivated
* only return sure grammar suggestions if it's close at least 2 characters long.

Need to add better specs and clean up lots of the logic to reduce # of loops on word list.